### PR TITLE
export JSON as Node module

### DIFF
--- a/json2.js
+++ b/json2.js
@@ -478,3 +478,5 @@ if (!JSON) {
         };
     }
 }());
+
+typeof module !== 'undefined' && module.exports && (module.exports = JSON);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "json-browser",
+  "description": "JSON in JavaScript",
+  "version": "2.0.0",
+  "homepage": "http://json.org",
+  "author": "Douglas Crockford",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/douglascrockford/JSON-js"
+  },
+  "main": "./json2.js"
+}


### PR DESCRIPTION
Hi Doug,
It would be great to have JSON2 as a Node module that can be installed with NPM. It's a small change that can go a long way.

With this change, users can install it

```
$ npm install json-browser
```

and use it:

```
var J = require('json-browser'),
// J.parse, J.stringify, etc.
```

cheers,
Dustin
