### PR TITLE
JSON Object prototype extensions

### DIFF
--- a/json2.js
+++ b/json2.js
@@ -280,13 +280,13 @@ if (!JSON) {
 // Is the value a date?
 
             if (Object.prototype.toString.apply(value) === '[object Date]') {
-                return isFinite(dt.valueOf()) ?
-                    dt.getUTCFullYear()     + '-' +
-                    f(dt.getUTCMonth() + 1) + '-' +
-                    f(dt.getUTCDate())      + 'T' +
-                    f(dt.getUTCHours())     + ':' +
-                    f(dt.getUTCMinutes())   + ':' +
-                    f(dt.getUTCSeconds())   + 'Z' : null;
+                return isFinite(value.valueOf()) ?
+                    value.getUTCFullYear()     + '-' +
+                    f(value.getUTCMonth() + 1) + '-' +
+                    f(value.getUTCDate())      + 'T' +
+                    f(value.getUTCHours())     + ':' +
+                    f(value.getUTCMinutes())   + ':' +
+                    f(value.getUTCSeconds())   + 'Z' : null;
             }
 
 // Is the value an array?


### PR DESCRIPTION
Hi Douglas!  I've used your excellent json2 library extensively, as I know many have, but I've recently run into trouble using it along with jquery's extend() on browsers that don't include native toJSON support. The issue is that the toJSON method on types like Boolean get moved over to the extended object and then an exception is thrown if toJSON is called under certain circumstances.

The patch in this pull request removes all global extensions of Object.prototype in favor of solving serialization issues locally. In general I think these extensions of Objects cause problems. 

Removed the addition of toJSON to certain Object prototypes (Date, Boolean, Number, String) when a native implementation isn't available. These types are now dealt with locally instead of globally.
