### PR TITLE
Allow compressors to replace the var names by using a reference to eval

### DIFF
--- a/json2.js
+++ b/json2.js
@@ -164,7 +164,7 @@ if (!JSON) {
     JSON = {};
 }
 
-(function () {
+(function (evil) {
     "use strict";
 
     function f(n) {
@@ -463,7 +463,7 @@ if (!JSON) {
 // in JavaScript: it can begin a block or an object literal. We wrap the text
 // in parens to eliminate the ambiguity.
 
-                j = eval('(' + text + ')');
+                j = evil('(' + text + ')');
 
 // In the optional fourth stage, we recursively walk the new structure, passing
 // each name/value pair to a reviver function for possible transformation.
@@ -477,4 +477,4 @@ if (!JSON) {
             throw new SyntaxError('JSON.parse');
         };
     }
-}());
+}(eval));


### PR DESCRIPTION
Allow compressors to replace the variable names by using a reference to eval (no eval in scope)

``` javascript
(function (eval_ref) {
  // better compression in this scope
  var o = eval_ref("(" + json + ")");
}(eval));
```
