### PR TITLE
Bug: primitives in Object-form are improperly handled by 'decycle()'.

### DIFF
--- a/cycle.js
+++ b/cycle.js
@@ -59,6 +59,14 @@ if (typeof JSON.decycle !== 'function') {
                     return null;
                 }
 
+                // these "objects" should all pass-through and not be handled by 'decycle'
+                if (value instanceof Date || value instanceof Boolean || 
+                    value instanceof String || value instanceof Number || 
+                    value instanceof RegExp
+                ) {
+                    return value;
+                }
+
 // If the value is an object or array, look to see if we have already
 // encountered it. If so, return a $ref/path object. This is a hard way,
 // linear search that will get slower as the number of unique objects grows.


### PR DESCRIPTION
An illustration of the bug:

```
var a = {b: "foobar"};
var c = {d: new String("foobar") };

JSON.stringify(a); // {"b":"foobar"}
JSON.stringify(c); // {"d":"foobar"}

JSON.stringify(JSON.decycle(a)); // {"b":"foobar"}
JSON.stringify(JSON.decycle(c)); // {"d":{"0":"f","1":"o","2":"o","3":"b","4":"a","5":"r"}}
```

This affects all the other Object-forms of the primitives, including `Date`, and causes them to be improperly processed by `decycle()`, since they are `typeof === "object"`, which deviates from how `JSON.stringify()` handles such values.
