### PR TITLE
Stringify fix : "Try catching" access to property to be more robust

### DIFF
--- a/json.js
+++ b/json.js
@@ -270,7 +270,16 @@ if (typeof JSON !== 'object') {
             length,
             mind = gap,
             partial,
+            value;
+            
+// Getters can generate errors and thus make our code crash, we shouldn't
+// allow this
+            
+        try {
             value = holder[key];
+        } catch (e) {
+            value = "Error while accessing property "+e;
+        }
 
 // If the value has a toJSON method, call it to obtain a replacement value.
 
@@ -526,4 +535,5 @@ if (typeof JSON !== 'object') {
             return JSON.parse(this, filter);
         };
     }
+    
 }());

--- a/json2.js
+++ b/json2.js
@@ -235,7 +235,17 @@ if (typeof JSON !== 'object') {
             length,
             mind = gap,
             partial,
+            value;
+
+// Getters can generate errors and thus make our code crash, we shouldn't
+// allow this
+            
+        try {
             value = holder[key];
+        } catch (e) {
+            value = "Error while accessing property "+e;
+        }
+
 
 // If the value has a toJSON method, call it to obtain a replacement value.
 
@@ -483,4 +493,6 @@ if (typeof JSON !== 'object') {
             throw new SyntaxError('JSON.parse');
         };
     }
+
 }());
+


### PR DESCRIPTION
``` javascript
var BuggyClass = function() {
        this.a = 12;

        this.__defineGetter__("work", function(){
            return "hello";
        });

        this.__defineGetter__("doesntWork", function(){
            return value.anything;
        });
    };

var buggyObject = new BuggyClass(),
    goodObject = {"a" : 12};


console.log(JSON.stringify(goodObject)); // works fine
console.log(JSON.stringify(buggyObject)); // crashes
```

This raised problems for debugger like node-codein https://github.com/ketamynx/node-codein/issues/3 when dependencies or user's code have getter only accessible following a given pattern. JSON.stringify could be more robust and just replace the error with an information.

If this is considered to be an error prone approach, maybe it would be a could thing to let user provide a function to handle error if he wishes it. Current situation is if a leaf of the object tree fails, the whole tree fails.
