### PR TITLE
Don't mess up objects by removing functions (or potentially any other type) when decycling them

### DIFF
--- a/cycle.js
+++ b/cycle.js
@@ -50,8 +50,7 @@ if (typeof JSON.decycle !== 'function') {
                 name,       // Property name
                 nu;         // The new object or array
 
-            switch (typeof value) {
-            case 'object':
+            if (typeof value == 'object') {
 
 // typeof null === 'object', so get out if this value is not really an object.
 // Also get out if it is a weird builtin object.
@@ -100,11 +99,9 @@ if (typeof JSON.decycle !== 'function') {
                     }
                 }
                 return nu;
-            case 'number':
-            case 'string':
-            case 'boolean':
-                return value;
             }
+
+            return value;
         }(object, '$'));
     };
 }


### PR DESCRIPTION
I had to change this in my own copy because it was removing functions from objects. It seems that when decycling there's no reason it should change objects other than removing cyclical references so it's appropriate to always return the value unless it's an object.
