### PR TITLE
toJSON polyfill for Chrome browser

### DIFF
--- a/json.js
+++ b/json.js
@@ -209,9 +209,9 @@ if (typeof JSON !== 'object') {
     }
 
     if (typeof Date.prototype.toJSON !== 'function') {
-
+        
         Date.prototype.toJSON = function (key) {
-
+            
             return isFinite(this.valueOf())
                 ?     this.getUTCFullYear()   + '-' +
                     f(this.getUTCMonth() + 1) + '-' +
@@ -221,12 +221,20 @@ if (typeof JSON !== 'object') {
                     f(this.getUTCSeconds())   + 'Z'
                 : null;
         };
-
-        String.prototype.toJSON      =
-            Number.prototype.toJSON  =
-            Boolean.prototype.toJSON = function (key) {
-                return this.valueOf();
-            };
+    }
+    
+    var toJSON = function (key) {
+        return this.valueOf();
+    };
+    
+    if (typeof String.prototype.toJSON !== 'function') {
+        String.prototype.toJSON = toJSON;
+    }
+    if (typeof Number.prototype.toJSON !== 'function') {
+        Number.prototype.toJSON = toJSON;
+    }
+    if (typeof Boolean.prototype.toJSON !== 'function') {
+        Boolean.prototype.toJSON = toJSON;
     }
 
     var cx,


### PR DESCRIPTION
There is an error in line https://github.com/meteor/meteor/blob/devel/packages/json/json2.js#L174. It checks if Date.prototype.toJSON is function. If it doesn't it sets toJSON function not only for Date prototype but also for String, Number and Boolean prototypes. However if Date.prototype.toJSON is function what is true in Chrome browser it doesn't set toJSON functions for other objects. And those objects (String, Number, Boolean) doesn't have toJSON functions in Chrome. So they are never set.
