### PR TITLE
Fix JSON.stringify(new Date(NaN)) in Safari

### DIFF
--- a/json2.js
+++ b/json2.js
@@ -191,6 +191,33 @@ if (typeof JSON !== 'object') {
         return this.valueOf();
     }
 
+    try {
+
+// Chrome: "null"
+// Firefox: "null"
+// IE: "null"
+// node.js: "null"
+// phantomjs: "null"
+// Safari: exception! (RangeError: Invalid Date)
+
+        JSON.stringify(new Date(NaN));
+    } catch (e) {
+
+// The bug that causes the aberrant behavior in Safari is in
+// Date.prototype.toJSON.  Clear it out so that we redefine it to be
+// the same as the other browsers and avoid JSON.stringify bugs in
+// Safari.
+//
+// NOTE: while this bug was originally found in Safari, it might be
+// present in other WebKit browsers.  This is why a feature-detection
+// approach is being used instead of checking navigator.appName or
+// similar.  Also, keep in mind that Safari isn't "evergreen" like
+// Chrome or Firefox; an update to fix this bug would require an OSX or
+// iOS upgrade.
+
+        Date.prototype.toJSON = undefined;
+    }
+
     if (typeof Date.prototype.toJSON !== 'function') {
 
         Date.prototype.toJSON = function () {


### PR DESCRIPTION
I recently found that Safari's `JSON.stringify` doesn't handle invalid dates correctly, leading to an exception that would stop the execution of code, unlike other browsers.  A bug similar to the below  example made it into our production system because Safari wasn't tested exhaustively.  This pull request works around the bug in Safari so that it behaves like Chrome, Firefox, etc.  The bug is present in all versions of Safari that I had available to test.

Example situation:

``` javascript
var s, numberOfDaysFromUserInput = NaN; // Imagine this came from a form field

s = JSON.stringify({
    name: "John Doe",
    tasks: [
        {
            title: "Take out the recycling",
            due_date: new Date((new Date()).getTime() + 1000 * 60 *
                60 * 24 * numberOfDaysFromUserInput)
        }
    ]
});

doSomethingWith(s);
```
