### PR TITLE
important: do not decycle if the object has a toJSON() method

### DIFF
--- a/cycle.js
+++ b/cycle.js
@@ -83,9 +83,9 @@ if (typeof JSON.decycle !== 'function') {
                     for (i = 0; i < value.length; i += 1) {
                         nu[i] = derez(value[i], path + '[' + i + ']');
                     }
-                } else {
+                } else if (typeof value.toJSON !== 'function') {
 
-// If it is an object, replicate the object.
+// If it is an object and does not take care of itself with toJSON(), replicate the object.
 
                     nu = {};
                     for (name in value) {


### PR DESCRIPTION
The assumption is that people who wrote the toJSON() know what
they are doing, possibly adding/removing important information.
In any case, an object with a toJSON() function will not run
into the "converting circular structure" problem.