### PR TITLE
Use CC-0 license

### DIFF
--- a/cycle.js
+++ b/cycle.js
@@ -2,9 +2,7 @@
     cycle.js
     2015-02-25
 
-    Public Domain.
-
-    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+    Published under the Creative Commons Zero v1.0 Universal (CC0-1.0) license.
 
     This code should be minified before deployment.
     See http://javascript.crockford.com/jsmin.html

--- a/json2.js
+++ b/json2.js
@@ -2,9 +2,7 @@
     json2.js
     2015-05-03
 
-    Public Domain.
-
-    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+    Published under the Creative Commons Zero v1.0 Universal (CC0-1.0) license.
 
     See http://www.JSON.org/js.html
 

--- a/json_parse.js
+++ b/json_parse.js
@@ -2,9 +2,7 @@
     json_parse.js
     2015-05-02
 
-    Public Domain.
-
-    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+    Published under the Creative Commons Zero v1.0 Universal (CC0-1.0) license.
 
     This file creates a json_parse function.
 

--- a/json_parse_state.js
+++ b/json_parse_state.js
@@ -2,9 +2,7 @@
     json_parse_state.js
     2015-05-02
 
-    Public Domain.
-
-    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+    Published under the Creative Commons Zero v1.0 Universal (CC0-1.0) license.
 
     This file creates a json_parse function.
 


### PR DESCRIPTION
Dear Mr Crockford,

Please consider specifying the Creative Commons Zero (CC-0) license for these works.

The term public domain probably does not really apply to this source code as it has not yet fallen out of copyright in most jurisdictions.

The CC-0 license achieves "public domain" equivalence through copyright.

SPDX Legal Team opinion:
http://wiki.spdx.org/view/Legal_Team/Decisions/Dealing_with_Public_Domain_within_SPDX_Files

Thank you.