### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "json2",
+  "version": "2015.5.3",
+  "description": "JSON in JavaScript",
+  "main": "json2.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/philippsimon/json2.git"
+  },
+  "keywords": [
+    "javascript",
+    "json",
+    "polyfill"
+  ],
+  "author": "Douglas Crockford (http://www.crockford.com/)",
+  "license": "Public Domain",
+  "bugs": {
+    "url": "https://github.com/philippsimon/json2/issues"
+  },
+  "homepage": "https://github.com/philippsimon/json2#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "json2",
-  "version": "2015.5.3",
+  "version": "2016.10.28",
   "description": "JSON in JavaScript",
   "main": "json2.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/philippsimon/json2.git"
+    "url": "git+https://github.com/douglascrockford/JSON-js.git"
   },
   "keywords": [
     "javascript",
@@ -15,7 +15,7 @@
   "author": "Douglas Crockford (http://www.crockford.com/)",
   "license": "Public Domain",
   "bugs": {
-    "url": "https://github.com/philippsimon/json2/issues"
+    "url": "https://github.com/douglascrockford/JSON-js/issues"
   },
-  "homepage": "https://github.com/philippsimon/json2#readme"
+  "homepage": "https://github.com/douglascrockford/JSON-js#readme"
 }


### PR DESCRIPTION
Dear @douglascrockford,
first of all thanks for writing this JSON library: It helps us a lot! (We develop HbbTV SmartTV apps and sadly still many devices don't fully support JSON).
The only problem we have at the moment is, that we can't install the json2 library through the npm package manager, as your repository misses a `package.json`.
It would be great if you could merge this pull request so we can use your library directly.
Thanks a lot in advance.
Kind regards,
@philippsimon